### PR TITLE
feat: [Auth] email auth expire event

### DIFF
--- a/src/auth-service/build.gradle.kts
+++ b/src/auth-service/build.gradle.kts
@@ -26,6 +26,8 @@ extra["springCloudVersion"] = "2023.0.0"
 dependencies {
     implementation("net.devh:grpc-spring-boot-starter:2.15.0.RELEASE")
     implementation(project(":common-module"))
+    // Kafka
+    implementation("org.springframework.kafka:spring-kafka")
 
     // Discovery
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
@@ -40,9 +42,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     // JWT
-    implementation ("io.jsonwebtoken:jjwt-api:0.11.5")
-    implementation ("io.jsonwebtoken:jjwt-impl:0.11.5")
-    implementation ("io.jsonwebtoken:jjwt-jackson:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
     // CircuitBreaker
 //    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j")
@@ -51,6 +53,7 @@ dependencies {
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 }
 
 dependencyManagement {

--- a/src/auth-service/src/main/java/org/palette/easelauthservice/config/KafkaProducer.java
+++ b/src/auth-service/src/main/java/org/palette/easelauthservice/config/KafkaProducer.java
@@ -1,0 +1,19 @@
+package org.palette.easelauthservice.config;
+
+import lombok.RequiredArgsConstructor;
+import org.palette.dto.EaselEvent;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, EaselEvent> kafkaTemplate;
+
+    @Async
+    public void execute(EaselEvent event) {
+        kafkaTemplate.send(event.getTopic(), event);
+    }
+}

--- a/src/auth-service/src/main/java/org/palette/easelauthservice/config/RedisConfig.java
+++ b/src/auth-service/src/main/java/org/palette/easelauthservice/config/RedisConfig.java
@@ -1,16 +1,25 @@
 package org.palette.easelauthservice.config;
 
+import lombok.RequiredArgsConstructor;
+import org.palette.easelauthservice.redis.event.EmailAuthExpirationListener;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyExpiredEvent;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @Configuration
 @EnableRedisRepositories
+@RequiredArgsConstructor
 public class RedisConfig {
+
+    private final EmailAuthExpirationListener listener;
 
     @Value("${spring.data.redis.host}")
     private String redisHost;
@@ -29,4 +38,20 @@ public class RedisConfig {
         return lettuceConnectionFactory;
     }
 
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(
+                (message, pattern) -> listener.onApplicationEvent(
+                        new RedisKeyExpiredEvent<>(message.getBody())),
+                new PatternTopic("__keyevent@*__:expired")
+        );
+        return container;
+    }
+
+    @Bean
+    public KeyExpirationEventMessageListener keyExpirationEventMessageListener(RedisMessageListenerContainer listenerContainer) {
+        return new KeyExpirationEventMessageListener(listenerContainer);
+    }
 }

--- a/src/auth-service/src/main/java/org/palette/easelauthservice/redis/event/EmailAuthExpirationListener.java
+++ b/src/auth-service/src/main/java/org/palette/easelauthservice/redis/event/EmailAuthExpirationListener.java
@@ -1,0 +1,24 @@
+package org.palette.easelauthservice.redis.event;
+
+import lombok.RequiredArgsConstructor;
+import org.palette.dto.event.TemporaryUserDeletionEvent;
+import org.palette.easelauthservice.config.KafkaProducer;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.redis.core.RedisKeyExpiredEvent;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class EmailAuthExpirationListener implements ApplicationListener<RedisKeyExpiredEvent<EmailAuthExpiredEvent>> {
+
+    private final KafkaProducer kafkaProducer;
+
+    @Override
+    public void onApplicationEvent(RedisKeyExpiredEvent<EmailAuthExpiredEvent> event) {
+        final String email = new String(event.getId(), StandardCharsets.UTF_8);
+        final TemporaryUserDeletionEvent temporaryUserDeletionEvent = new TemporaryUserDeletionEvent(email);
+        kafkaProducer.execute(temporaryUserDeletionEvent);
+    }
+}

--- a/src/auth-service/src/main/java/org/palette/easelauthservice/redis/event/EmailAuthExpiredEvent.java
+++ b/src/auth-service/src/main/java/org/palette/easelauthservice/redis/event/EmailAuthExpiredEvent.java
@@ -1,0 +1,16 @@
+package org.palette.easelauthservice.redis.event;
+
+import lombok.Getter;
+import org.palette.easelauthservice.redis.EmailAuth;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class EmailAuthExpiredEvent extends ApplicationEvent {
+
+    private final EmailAuth emailAuth;
+
+    public EmailAuthExpiredEvent(EmailAuth emailAuth) {
+        super(emailAuth);
+        this.emailAuth = emailAuth;
+    }
+}

--- a/src/auth-service/src/main/resources/application.yml
+++ b/src/auth-service/src/main/resources/application.yml
@@ -23,6 +23,12 @@ spring:
       host: ${AUTH_REDIS_HOST}
       port: ${AUTH_REDIS_PORT}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_SERVERS}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
 jwt:
   secret-key: ${AUTH_JWT_SECRET_KEY}
 

--- a/src/common-module/src/main/java/org/palette/dto/event/TemporaryUserDeletionEvent.java
+++ b/src/common-module/src/main/java/org/palette/dto/event/TemporaryUserDeletionEvent.java
@@ -1,9 +1,7 @@
 package org.palette.dto.event;
 
-import lombok.Getter;
 import org.palette.dto.EaselEvent;
 
-@Getter
 public record TemporaryUserDeletionEvent(String email) implements EaselEvent {
 
     @Override


### PR DESCRIPTION
## Related Issue

#251 

<!-- 관련 이슈를 링크해 주세요. 이를 통해 해당 PR과 연결된 문제를 명확하게 할 수 있습니다. -->

## Changes
<!-- 이 PR로 인해 바뀌는 것이 무엇인지 상세하게 적어주세요. 이유가 있다면 연결해 주세요 -->

`EmailAuth`에 할당한 ttl이 지나면 Redis에서 expire되고, 이때 발생한 `RedisKeyExpiredEvent`메시지를 수신하여 이벤트 브로커로 전파합니다. 

## Screenshots

<!-- PR의 변경사항을 보여주는 스크린샷. 필요시 추가하세요. -->

## To Reviewer

<!-- 리뷰어에게 별도로 전달하고 싶은 내용이 있다면 입력하세요. -->

## Additional Context(optional)

common 모듈 업데이트 있습니다. Kafka Event 관련

해당 event를 user service에서 consume하여 db에서 삭제 처리하는 로직을 마저 작업하겠습니다.

<!-- 추가적인 문맥: 레퍼런스, 종속성 변경 등 PR과는 직접적으로 관련되지 않은 정보를 입력하세요. -->

## How Has This Been Tested?

<!-- PR이 동작하는지 확인하기 위한 테스트 방법 및 케이스를 상세하게 설명해주세요. -->

## Checklist

<!-- PR 등록 전 확인해 주세요! -->

- [x] PR 제목은 포맷과 내용 둘 다 알맞게 작성되었는가
- [x] PR에 대해 구체적으로 설명이 되어있는가
